### PR TITLE
Add docker command to access CLI to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ I moved the repo to quay.io for automated updates, the dockerhub version is now 
 3. Done! Your server should now be accessible.
 
 ### Mods
-Mods can be installed by running  
+Mods can be installed by running:
 ```docker run --rm -v $PWD:/screeps quay.io/ags131/screeps-server yarn add screepsmod-auth```
 
+### CLI
+The CLI can be accessed by running:
+```docker exec -it screeps-server screeps cli```
 
 ## Stopping and starting the server
 Stop:


### PR DESCRIPTION
w4rl0ck on slack reported that they needed quotes around the `"screeps cli"` on MacOS, but I was [reading the docs](https://docs.docker.com/engine/reference/commandline/exec/#extended-description) and they very explicitly say not to do that and doing that on linux caused failures as it couldn't find the binary named `sceeps cli` with the space it in.

