### PR TITLE
Alpine Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
-FROM node:10.16.3-stretch
-ENV SCREEPS_VERSION 4.2.3
-WORKDIR /screeps
-RUN yarn add screeps@"$SCREEPS_VERSION"
-
-FROM node:10.16.3-stretch
+FROM node:12-alpine
+ENV SCREEPS_VERSION latest
 VOLUME /screeps
 WORKDIR /screeps
+
+RUN apk add --no-cache bash make g++ python2 \
+  && yarn add screeps@"$SCREEPS_VERSION" \
+  && yarn cache clean
 ENV DB_PATH=/screeps/db.json ASSET_DIR=/screeps/assets \
         MODFILE=/screeps/mods.json GAME_PORT=21025 \
         GAME_HOST=0.0.0.0 CLI_PORT=21026 CLI_HOST=0.0.0.0 \
         STORAGE_PORT=21027 STORAGE_HOST=localhost \
-        DRIVER_MODULE="@screeps/driver"
-WORKDIR /screeps
-#RUN apk add --no-cache git
-COPY --from=0 /screeps /screeps
+        DRIVER_MODULE="@screeps/driver" STEAM_API_KEY=''
 
 COPY "docker-entrypoint.sh" /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are two different type how to start a screeps server.
 If you do not have an existing server directory, just start the Docker container with the command line argument `init`, and everything gets done for you.
 
 ```bash
-docker run -it --rm -v $PWD:/screeps eadword/screeps-server init
+docker run -it --rm -v $PWD:/screeps quay.io/ags131/screeps-server init
 ```
 
 Now it's all set to run the Screeps server.
@@ -19,7 +19,7 @@ If you have already a server directory (from previous installations) follow the 
 1. Make sure you are in the server directory
 2. Run the server
 ```bash
-docker run -d --name screeps-server -v $PWD:/screeps -p 21025:21025 eadword/screeps-server
+docker run -d --name screeps-server -v $PWD:/screeps -p 21025:21025 quay.io/ags131/screeps-server
 ```
 
 ## Managing the server
@@ -27,7 +27,7 @@ docker run -d --name screeps-server -v $PWD:/screeps -p 21025:21025 eadword/scre
 
 ### Mods
 Mods can be installed by running:
-```docker run --rm -v $PWD:/screeps eadword/screeps-server yarn add screepsmod-auth```
+```docker run --rm -v $PWD:/screeps quay.io/ags131/screeps-server yarn add screepsmod-auth```
 
 ### CLI
 The CLI can be accessed by running:
@@ -49,5 +49,5 @@ Start:
 
 ## Launching a specific module
 For more advanced usage and more control over scaling, you can launch individual modules. Note that each module may have different environment variables needed to run.
-```docker run -d --name screeps-server-backend -v $PWD:/screeps eadword/screeps-server@beta screeps-backend```
+```docker run -d --name screeps-server-backend -v $PWD:/screeps quay.io/ags131/screeps-server@beta screeps-backend```
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ There are two different type how to start a screeps server.
 If you do not have an existing server directory, just start the Docker container with the command line argument `init`, and everything gets done for you.
 
 ```bash
-docker run -it --rm -v $PWD:/screeps quay.io/ags131/screeps-server init
+docker run -it --rm -v $PWD:/screeps eadword/screeps-server init
 ```
+
 Now it's all set to run the Screeps server.
 
 ## Running the server
@@ -18,7 +19,7 @@ If you have already a server directory (from previous installations) follow the 
 1. Make sure you are in the server directory
 2. Run the server
 ```bash
-docker run -d --name screeps-server -v $PWD:/screeps -p 21025:21025 quay.io/ags131/screeps-server
+docker run -d --name screeps-server -v $PWD:/screeps -p 21025:21025 eadword/screeps-server
 ```
 
 ## Managing the server
@@ -26,7 +27,7 @@ docker run -d --name screeps-server -v $PWD:/screeps -p 21025:21025 quay.io/ags1
 
 ### Mods
 Mods can be installed by running:
-```docker run --rm -v $PWD:/screeps quay.io/ags131/screeps-server yarn add screepsmod-auth```
+```docker run --rm -v $PWD:/screeps eadword/screeps-server yarn add screepsmod-auth```
 
 ### CLI
 The CLI can be accessed by running:
@@ -48,5 +49,5 @@ Start:
 
 ## Launching a specific module
 For more advanced usage and more control over scaling, you can launch individual modules. Note that each module may have different environment variables needed to run.
-```docker run -d --name screeps-server-backend -v $PWD:/screeps quay.io/ags131/screeps-server@beta screeps-backend```
+```docker run -d --name screeps-server-backend -v $PWD:/screeps eadword/screeps-server@beta screeps-backend```
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,11 @@ function init_srv(){
 	echo "===== SETTING UP SCREEPS ====="
 	yarn init -y
 	yarn add screeps
-	npx screeps init
+	if [ -n "$STEAM_API_KEY" ]; then
+	  echo "$STEAM_API_KEY" | npx screeps init >/dev/null
+	else
+		npx screeps init
+	fi
 }
 
 function run_srv(){


### PR DESCRIPTION
Switched to Node 12 alpine image. During the process of converting I noticed that it requires the same build tools for running the init script, so I don't think there is any benefit to a multi-stage build here, but I do make sure to clean the cache in between.

This gets the image down from 1.1GiB to 300MiB, so I will call it a win. I have tested the image and it seems to be working. This may cause some issues with some mods, but the solution is probably just an apk add away.